### PR TITLE
Issue #71 - Added "All Players" checkbox to Reset Rest dialog, added …

### DIFF
--- a/css/eclipsephase.css
+++ b/css/eclipsephase.css
@@ -282,6 +282,10 @@
   margin-top: 20px;
 }
 
+.eclipsephase.reset-rest-all-dialog .form-group-stacked {
+  text-align: right;
+}
+
 .morph-img{
   margin: -10px 0 10px 10px;
   max-width: 210px;

--- a/lang/en.json
+++ b/lang/en.json
@@ -1382,8 +1382,8 @@
     "systemMessage": {
       "resetRest": {
         "title": "Reset Rest",
-        "copy": "This dialog resets ALL rest for the selected, active characters. If a character is not actively controlled by any player, it will not show in this list. Players can change their active character by using the player menu in the lower left of foundry.",
-        "headline": "Active Player Characters"
+        "copy": "This dialog resets ALL rest for the selected characters. If a character is actively controlled by a player, it will be selected by default. Check the All players box to select all characters or uncheck it to select only the active characters.",
+        "headline": "Player Characters"
       }
     }
   }

--- a/module/eclipsephase.js
+++ b/module/eclipsephase.js
@@ -218,6 +218,11 @@ Hooks.once('init', async function() {
     return '> ' + JSON.stringify(obj)
   })
 
+  // Helper to set checked attribute on checkboxes within template
+  Handlebars.registerHelper("checkedIf", function (condition) {
+    return (condition) ? "checked" : "";
+  });
+
   registerSystemSettings();
 });
 

--- a/templates/chat/list-dialog.html
+++ b/templates/chat/list-dialog.html
@@ -146,28 +146,5 @@
             </div>
             {{/each}}
         </div>
-
-    {{else}}
-
-        <div class="form-group listBackgroundMain">
-            <p>{{{localize "ep2e.systemMessage.resetRest.copy"}}}</p>
-        </div>
-        {{#if (gt charCount 0)}}
-            <div class="flexrow subheader">
-                <h3 class="subheader dialog">{{localize "ep2e.systemMessage.resetRest.headline"}}</h3>
-            </div>
-            <div class="grid" style="margin-top: 0;">
-                {{#each charList as |char|}}
-                <div>
-                    <input type="checkbox" name="{{char._id}}" checked>
-                    <label class="resource-label">{{char.name}}</label>
-                </div>
-                {{/each}}
-            </div>
-        {{else}}
-            <div style="height: 190px">
-                <img src="systems/eclipsephase/resources/img/userConfiguration.webp"/>
-            </div>
-        {{/if}}
     {{/if}}
 </form>

--- a/templates/menu/menu-list-dialog.html
+++ b/templates/menu/menu-list-dialog.html
@@ -1,0 +1,28 @@
+<form class="eclipsephase reset-rest-all-dialog">
+  <div class="form-group listBackgroundMain">
+    <p>{{{localize "ep2e.systemMessage.resetRest.copy"}}}</p>
+  </div>
+  {{#if (gt charCount 0)}}
+  <div class="flexrow subheader">
+    <h3 class="subheader dialog">{{localize "ep2e.systemMessage.resetRest.headline"}}</h3>
+  </div>
+  <div class="form-group-stacked">
+    <div class="checkbox-label">
+      <label class="checkbox">{{localize "OWNERSHIP.AllPlayers"}}</label>
+      <input type="checkbox" id="resetRestSelectAll">
+    </div>
+    <div class="grid" style="margin-top: 0;">
+      {{#each charList as |char|}}
+      <div>
+        <label>{{char.actor.name}}</label>
+        <input type="checkbox" data-checkbox-type="player-character" data-owner-id="{{char.ownedByPlayer}}" name="{{char.actor._id}}" {{checkedIf char.ownedByPlayer}}>
+      </div>
+      {{/each}}
+    </div>
+  </div>
+  {{else}}
+  <div style="height: 190px">
+    <img src="systems/eclipsephase/resources/img/userConfiguration.webp"/>
+  </div>
+  {{/if}}
+</form>


### PR DESCRIPTION
…all player character sheets to list, default to active players checked.

Also re-factored the template for the Reset Rest dialog out of the generic list dialog template.

I moved the checkbox to after the label to match the Show Players dialog.  I didn't match the exact layout of that dialog because I think it looks janky, using the grid layout instead, as the Reset Rest All players dialog had.

This can be easily changed or tweaked if you want.